### PR TITLE
fix for mysql >= 8

### DIFF
--- a/src/LibHdb++MySQL.h
+++ b/src/LibHdb++MySQL.h
@@ -35,6 +35,14 @@
 #include <tango.h>
 //#include <event.h>
 
+// MySQL 8.0 or later removed my_bool typedef.
+// Reintroduce it as a bandaid fix.
+// See https://bugs.mysql.com/?id=87337
+// fix taken from here: https://github.com/rathena/rathena/blob/master/src/common/sql.cpp
+#if !defined(MARIADB_BASE_VERSION) && !defined(MARIADB_VERSION_ID) && MYSQL_VERSION_ID >= 80001 && MYSQL_VERSION_ID != 80002
+#define my_bool bool
+#endif
+
 #define TYPE_SCALAR					"scalar"
 #define TYPE_ARRAY					"array"
 


### PR DESCRIPTION
this patch creates compatibility with mysql client version 8, which removed the my_bool definition
the polyfill checks for the version and leaves out the definition for previous versions, see also in code comments